### PR TITLE
Control order of location nodes.

### DIFF
--- a/oai-mods-add-thumbnail-url.xsl
+++ b/oai-mods-add-thumbnail-url.xsl
@@ -28,12 +28,10 @@
         mods:relatedItem.
     -->
     <xsl:template match="mods:location[not(parent::mods:relatedItem)]">
-        <xsl:copy>
-            <xsl:apply-templates select="@*|node()"/>
-            <!--
-                constructing elements to avoid copied namespaces.
-                also, i'm a bit lazy.
-            -->
+        <location>
+            <xsl:copy-of select="mods:physicalLocation"/>
+            <xsl:copy-of select="mods:shelfLocator"/>
+            <!-- Add urls where they are allowed-->
             <xsl:element name="url">
                 <xsl:attribute name="access">
                     <xsl:value-of select="'object in context'"/>
@@ -49,7 +47,9 @@
                 </xsl:attribute>
                 <xsl:value-of select="concat(following::mods:identifier[starts-with(.,'http')],'/datastream/TN/view')"/>
             </xsl:element>
-        </xsl:copy>
+            <xsl:copy-of select="mods:holdingSimple"/>
+            <xsl:copy-of select="mods:holdingExternal"/>
+        </location>
     </xsl:template>
     
     <!-- 


### PR DESCRIPTION
**GitHub Issue**: [DLTN_XSLT-165](https://github.com/DigitalLibraryofTennessee/DLTN_XSLT/issues/165)

# What does this do

The current transform concatenates urls after whatever nodes exist in location.  This can lead to validity problems if the location node already has holdingSimples or holdingExternals.  This fixes this by being deterministic about what goes where.

# Interested Parties

@CanOfBees @mlhale7 @pc37utn 